### PR TITLE
[GOVCMSD8-570] Replace deprecated methods with those compatible with …

### DIFF
--- a/consultation.info.yml
+++ b/consultation.info.yml
@@ -2,6 +2,7 @@ name: Consultation
 type: module
 description: Provides a Consultation for accepting submissions.
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: GovCMS
 configure: consultation.settings
 dependencies:

--- a/consultation.module
+++ b/consultation.module
@@ -176,7 +176,7 @@ function consultation_preprocess_paragraph(&$variables) {
   if ($pg->bundle() == 'consultation_updates') {
     $term = $pg->field_cons_update_type->entity;
     if ($term && $file = $term->field_cons_update_type_icon->entity) {
-      $variables['icon_path'] = $file->URL();
+      $variables['icon_path'] = $file->toUrl();
     }
     else {
       $module_path = drupal_get_path('module', 'consultation');
@@ -187,13 +187,13 @@ function consultation_preprocess_paragraph(&$variables) {
   // Prepare variables for consultation_document paragraph.
   if ($pg->bundle() == 'consultation_documentation') {
     if ($file = $pg->field_cons_file_pdf->entity) {
-      $variables['pdf_path'] = $file->URL();
+      $variables['pdf_path'] = $file->toUrl();
       $variables['pdf_mime'] = $file->filemime->value;
       $variables['pdf_size'] = $file->filesize->value;
       $variables['pdf_size_readable'] = format_size($file->filesize->value);
     }
     if ($file = $pg->field_cons_file_word->entity) {
-      $variables['doc_path'] = $file->URL();
+      $variables['doc_path'] = $file->toUrl();
       $variables['doc_mime'] = $file->filemime->value;
       $variables['doc_size'] = $file->filesize->value;
       $variables['doc_size_readable'] = format_size($file->filesize->value);


### PR DESCRIPTION
#### Fix following compatible issues with Drupal 9:

- Call to deprecated method url() of class Drupal\Core\Entity\EntityInterface. Deprecated in drupal:8.0.0 and is removed from drupal:9.0.0. Use toUrl() instead.
- Add core_version_requirement: ^8 || ^9 to consultation.info.yml to designate that the module is compatible with Drupal 9. 